### PR TITLE
Use node_id for FD and add stdio support

### DIFF
--- a/process/src/lib.rs
+++ b/process/src/lib.rs
@@ -7,7 +7,7 @@ extern crate alloc;
 use core::alloc::Layout;
 use framebuffer::println;
 use memory::vmm::{PageTable, VMM};
-use vfs::{FD, VfsNode, vfs_close};
+use vfs::{FD, STDIN_NODE_ID, STDOUT_NODE_ID, STDERR_NODE_ID, O_RDONLY, O_WRONLY, vfs_close};
 
 const KERNEL_STACK_SIZE: usize = 64 * 1024;
 const MAX_PROCESSES: usize = 64;
@@ -49,19 +49,39 @@ pub struct Process {
 }
 
 impl Process {
+    /// Returns the index of the first empty FD slot at index ≥ 3 (0–2 are
+    /// reserved for stdin/stdout/stderr).
     pub fn get_free_fd_index(&self) -> Option<usize> {
-        self.fildes.iter().position(|fd| fd.is_empty())
+        self.fildes[3..].iter().position(|fd| fd.is_empty()).map(|i| i + 3)
     }
 
-    pub fn open_file(&mut self, node: *mut VfsNode, flags: u32) -> Option<usize> {
+    /// Opens `node_id` in this process and returns the assigned FD index.
+    /// Returns `None` when the FD table is full.
+    pub fn open_fd(&mut self, node_id: u32, flags: u32) -> Option<usize> {
         let idx = self.get_free_fd_index()?;
-        self.fildes[idx] = FD {
-            vfs_node: node,
-            offset: 0,
-            flags,
-            ref_count: 1,
-        };
+        self.fildes[idx] = FD { node_id, flags, ref_count: 1 };
         Some(idx)
+    }
+
+    /// Closes the FD at `fd`. Decrements the ref-count and removes the
+    /// backing VFS node when it reaches zero.
+    /// Returns `false` when `fd` is out of range or already closed.
+    pub fn close_fd(&mut self, fd: usize) -> bool {
+        if fd >= self.fildes.len() {
+            return false;
+        }
+        let entry = &mut self.fildes[fd];
+        if entry.is_empty() {
+            return false;
+        }
+        entry.ref_count = entry.ref_count.saturating_sub(1);
+        if entry.ref_count == 0 {
+            if !entry.is_special() {
+                let _ = vfs_close(entry.node_id);
+            }
+            *entry = FD::EMPTY;
+        }
+        true
     }
 }
 
@@ -73,6 +93,11 @@ pub struct ProcessTable {
 pub fn init_kernel_process(rsp: u64) {
     let kernel_pml4 = VMM::get_page_table();
 
+    let mut fildes = [FD::EMPTY; 1024];
+    fildes[0] = FD { node_id: STDIN_NODE_ID,  flags: O_RDONLY, ref_count: 1 };
+    fildes[1] = FD { node_id: STDOUT_NODE_ID, flags: O_WRONLY, ref_count: 1 };
+    fildes[2] = FD { node_id: STDERR_NODE_ID, flags: O_WRONLY, ref_count: 1 };
+
     let process = Process {
         pid: 0,
         rsp,
@@ -81,6 +106,7 @@ pub fn init_kernel_process(rsp: u64) {
         pml4: kernel_pml4,
         state: ProcessState::Running,
         priority: Priority::Idle,
+        fildes,
         ticks_ready: 0,
         wake_at_tick: 0,
     };
@@ -109,7 +135,10 @@ pub fn create_process(entry: *mut ()) -> Option<u64> {
         let user_pml4 = mapper.create_user_pml4()?;
         println!("Created");
 
-        let fildes = [FD::EMPTY; 1024];
+        let mut fildes = [FD::EMPTY; 1024];
+        fildes[0] = FD { node_id: STDIN_NODE_ID,  flags: O_RDONLY, ref_count: 1 };
+        fildes[1] = FD { node_id: STDOUT_NODE_ID, flags: O_WRONLY, ref_count: 1 };
+        fildes[2] = FD { node_id: STDERR_NODE_ID, flags: O_WRONLY, ref_count: 1 };
 
         let process = Process {
             pid,
@@ -140,13 +169,14 @@ pub fn destroy_process(pid: u64) -> bool {
         if let Some(mut process) = PROCESS_TABLE.processes[pid as usize].take() {
             for fd in process.fildes.iter_mut() {
                 if !fd.is_empty() {
-                    fd.ref_count -= 1;
-                    
+                    fd.ref_count = fd.ref_count.saturating_sub(1);
                     if fd.ref_count == 0 {
-                        vfs_close(fd.vfs_node.id);
-                        println!("Closed VFS node at 0x{:x}", fd.vfs_node as usize);
+                        if !fd.is_special() {
+                            let _ = vfs_close(fd.node_id);
+                            println!("Closed VFS node {}", fd.node_id);
+                        }
+                        *fd = FD::EMPTY;
                     }
-                    *fd = FD::EMPTY;
                 }
             }
             if !process.stack_base.is_null() {

--- a/syscall/src/syscall_handler.rs
+++ b/syscall/src/syscall_handler.rs
@@ -1,8 +1,8 @@
 //! Object based syscall dispatch and handler implementations.
 
 use limine::request::FramebufferRequest;
-use framebuffer::println;
-use vfs::{vfs_close, vfs_open};
+use framebuffer::{print, println};
+use vfs::{vfs_close, vfs_open, vfs_read, vfs_write_node, STDIN_NODE_ID, STDOUT_NODE_ID, STDERR_NODE_ID};
 use memory::allocator::sbrk;
 use process;
 
@@ -11,6 +11,8 @@ unsafe extern "C" {
 }
 
 const ENOSYS: i64 = -38;
+const EBADF:  i64 = -9;
+const EINVAL: i64 = -22;
 
 #[repr(u64)]
 pub enum Syscall {
@@ -21,6 +23,8 @@ pub enum Syscall {
     Close           = 4,
     Sbrk            = 5,
     GetPid          = 6,
+    Read            = 7,
+    Write           = 8,
 }
 
 impl Syscall {
@@ -33,6 +37,8 @@ impl Syscall {
             4 => Some(Self::Close),
             5 => Some(Self::Sbrk),
             6 => Some(Self::GetPid),
+            7 => Some(Self::Read),
+            8 => Some(Self::Write),
             _ => None,
         }
     }
@@ -54,6 +60,8 @@ impl SyscallHandler {
             Some(Syscall::Close)           => self.close(arg1),
             Some(Syscall::Sbrk)            => self.sbrk(arg1),
             Some(Syscall::GetPid)          => self.get_pid(),
+            Some(Syscall::Read)            => self.read(arg1, arg2, arg3),
+            Some(Syscall::Write)           => self.write(arg1, arg2, arg3),
             None => ENOSYS,
         }
     }
@@ -107,34 +115,131 @@ impl SyscallHandler {
         0
     }
 
+    /// open(path_ptr, path_len, flags) -> fd | -errno
+    ///
+    /// Opens the file at `path` with the given `flags`, registers the backing
+    /// VFS node in the current process's FD table, and returns the FD index.
     fn open(&self, ptr: i64, len: i64, flags: i64) -> i64 {
         let ptr = ptr as *const u8;
         let len = len as usize;
-        if ptr.is_null() || len == 0 {
-            return -1;
+        if ptr.is_null() || len == 0 || len > 4096 {
+            return EINVAL;
         }
         let slice = unsafe { core::slice::from_raw_parts(ptr, len) };
         let path = match core::str::from_utf8(slice) {
             Ok(s)  => s,
+            Err(_) => return EINVAL,
+        };
+        let flags_u32 = flags as u32;
+        let node = match vfs_open(path, flags_u32, 0) {
+            Ok(n)  => n,
             Err(_) => return -1,
         };
-        match vfs_open(path, flags as u32, 0) {
-            Ok(node) => node.id as i64,
-            Err(_)   => -1,
+        let node_id = node.id;
+        let proc = match process::get_current_process_mut() {
+            Some(p) => p,
+            None => {
+                let _ = vfs_close(node_id);
+                return -1;
+            }
+        };
+        match proc.open_fd(node_id, flags_u32) {
+            Some(fd_idx) => fd_idx as i64,
+            None => {
+                let _ = vfs_close(node_id);
+                -1
+            }
         }
     }
 
-    fn close(&self, node_id: i64) -> i64 {
-        match vfs_close(node_id as u32) {
-            Ok(_)  => 0,
-            Err(_) => -1,
+    /// close(fd) -> 0 | -errno
+    fn close(&self, fd: i64) -> i64 {
+        if fd < 0 || fd > 1023 {
+            return EBADF;
+        }
+        let proc = match process::get_current_process_mut() {
+            Some(p) => p,
+            None    => return -1,
+        };
+        if proc.close_fd(fd as usize) { 0 } else { EBADF }
+    }
+
+    /// read(fd, buf, count) -> bytes_read | -errno
+    ///
+    /// Reads up to `count` bytes from `fd` into `buf`.
+    /// Returns the number of bytes placed in `buf`, or a negative errno.
+    /// Reading from stdin (FD 0) always returns 0 (no data yet).
+    fn read(&self, fd: i64, buf: i64, count: i64) -> i64 {
+        if fd < 0 || fd > 1023 {
+            return EBADF;
+        }
+        if buf == 0 || count < 0 {
+            return EINVAL;
+        }
+        if count == 0 {
+            return 0;
+        }
+        let proc = match process::get_current_process() {
+            Some(p) => p,
+            None    => return -1,
+        };
+        let entry = &proc.fildes[fd as usize];
+        if entry.is_empty() {
+            return EBADF;
+        }
+        // stdin has no backing data yet
+        if entry.node_id == STDIN_NODE_ID {
+            return 0;
+        }
+        let data = match vfs_read(entry.node_id, count as usize) {
+            Ok(d)  => d,
+            Err(_) => return -1,
+        };
+        let n = data.len();
+        if n > 0 {
+            unsafe {
+                core::ptr::copy_nonoverlapping(data.as_ptr(), buf as *mut u8, n);
+            }
+        }
+        n as i64
+    }
+
+    /// write(fd, buf, count) -> bytes_written | -errno
+    ///
+    /// Writes `count` bytes from `buf` to `fd`.
+    /// Writes to stdout (FD 1) and stderr (FD 2) are routed to the framebuffer.
+    fn write(&self, fd: i64, buf: i64, count: i64) -> i64 {
+        if fd < 0 || fd > 1023 {
+            return EBADF;
+        }
+        if buf == 0 || count < 0 {
+            return EINVAL;
+        }
+        if count == 0 {
+            return 0;
+        }
+        let proc = match process::get_current_process() {
+            Some(p) => p,
+            None    => return -1,
+        };
+        let entry = &proc.fildes[fd as usize];
+        if entry.is_empty() {
+            return EBADF;
+        }
+        let node_id = entry.node_id;
+        let data = unsafe { core::slice::from_raw_parts(buf as *const u8, count as usize) };
+        // stdout / stderr → framebuffer
+        if node_id == STDOUT_NODE_ID || node_id == STDERR_NODE_ID {
+            if let Ok(s) = core::str::from_utf8(data) {
+                print!("{}", s);
+            }
+            return count;
+        }
+        match vfs_write_node(node_id, data) {
+            Ok(())  => count,
+            Err(_)  => -1,
         }
     }
-
-    fn read(&self, ) {
-
-    }
-
     fn sbrk(&self, increment: i64) -> i64 {
         let ptr = sbrk(increment as isize);
         if ptr.is_null() {

--- a/vfs/src/lib.rs
+++ b/vfs/src/lib.rs
@@ -45,6 +45,13 @@ pub const S_IROTH: u32 = 0o004;
 /// Convenience mode: rw-r--r--
 pub const S_IFREG: u32 = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
 
+/// VFS node ID reserved for the process stdin stream.
+pub const STDIN_NODE_ID:  u32 = 1;
+/// VFS node ID reserved for the process stdout stream.
+pub const STDOUT_NODE_ID: u32 = 2;
+/// VFS node ID reserved for the process stderr stream.
+pub const STDERR_NODE_ID: u32 = 3;
+
 /// Volume statistics returned by [`FileSystem::stat_fs`].
 pub struct FsInfo {
     pub total_bytes: u64,
@@ -89,24 +96,33 @@ pub struct VfsNode {
     pub mode:   u32,
 }
 
-#[derive(Clone, Debug)]
+/// A kernel file descriptor stored in each process's per-process FD table.
+///
+/// Node IDs 1–3 are reserved for stdin, stdout, and stderr and are never
+/// backed by a real VFS node. Node ID 0 means the slot is empty/closed.
+#[derive(Clone, Copy, Debug)]
 pub struct FD {
-    pub vfs_node: *mut VfsNode, // Pointer to file or device
-    pub offset:    u32,         // Current read/write position
-    pub flags:     u32,         // Perms
-    pub ref_count: u32,         // How many file descriptors point here
+    /// Backing VFS node ID. `0` means this slot is empty/closed.
+    pub node_id:   u32,
+    /// Open flags (e.g. [`O_RDWR`]).
+    pub flags:     u32,
+    /// Number of file descriptors in this process sharing this VFS node.
+    /// Reaches 0 only via `dup`/`dup2` semantics; starts at 1 on `open`.
+    pub ref_count: u32,
 }
 
 impl FD {
-    pub const EMPTY: Self = Self {
-        vfs_node: core::ptr::null_mut(),
-        offset: 0,
-        flags: 0,
-        ref_count: 0,
-    };
+    pub const EMPTY: Self = Self { node_id: 0, flags: 0, ref_count: 0 };
 
-    pub fn is_empty(&self) -> bool {
-        self.vfs_node.is_null()
+    /// Returns `true` when this descriptor slot is not in use.
+    #[inline]
+    pub fn is_empty(&self) -> bool { self.node_id == 0 }
+
+    /// Returns `true` for the three reserved pseudo-descriptors (stdin/stdout/stderr).
+    /// These are never closed through the VFS node table.
+    #[inline]
+    pub fn is_special(&self) -> bool {
+        self.node_id >= STDIN_NODE_ID && self.node_id <= STDERR_NODE_ID
     }
 }
 
@@ -312,7 +328,8 @@ unsafe impl Sync for NodeTable {}
 static VFS_LOCK:    AtomicBool = AtomicBool::new(false);
 static MOUNT_TABLE: MountTable = MountTable(UnsafeCell::new(None));
 static NODE_TABLE:  NodeTable  = NodeTable(UnsafeCell::new(None));
-static NEXT_NODE_ID: AtomicU32 = AtomicU32::new(1);
+// Node IDs 1–3 are reserved for stdin/stdout/stderr; real nodes start at 4.
+static NEXT_NODE_ID: AtomicU32 = AtomicU32::new(4);
 
 fn vfs_lock() {
     while VFS_LOCK
@@ -518,9 +535,10 @@ pub fn vfs_read_file(path: &str) -> Result<Vec<u8>, &'static str> {
     result
 }
 
-/// Reads from an open node starting at its cursor. Advances cursor to end.
+/// Reads up to `max_count` bytes from an open node at its cursor position.
+/// Advances the cursor by the number of bytes actually read.
 /// Fails if the node was opened write-only.
-pub fn vfs_read_node(node_id: u32) -> Result<Vec<u8>, &'static str> {
+pub fn vfs_read(node_id: u32, max_count: usize) -> Result<Vec<u8>, &'static str> {
     vfs_lock();
     let result = (|| {
         let node = get_node(node_id)?;
@@ -534,12 +552,21 @@ pub fn vfs_read_node(node_id: u32) -> Result<Vec<u8>, &'static str> {
         let fs    = get_fs(node.mount)?;
         let data  = fs.read_file(&node.name.clone())?;
         let start = node.cursor as usize;
-        let slice = if start < data.len() { data[start..].to_vec() } else { Vec::new() };
-        node.cursor = node.size;
+        let avail = data.len().saturating_sub(start);
+        let count = avail.min(max_count);
+        let slice = if count > 0 { data[start..start + count].to_vec() } else { Vec::new() };
+        node.cursor += count as u32;
         Ok(slice)
     })();
     vfs_unlock();
     result
+}
+
+/// Reads from an open node starting at its cursor all the way to EOF.
+/// Advances the cursor to the end of the file.
+/// Fails if the node was opened write-only.
+pub fn vfs_read_node(node_id: u32) -> Result<Vec<u8>, &'static str> {
+    vfs_read(node_id, usize::MAX)
 }
 
 /// Creates a new file by path.


### PR DESCRIPTION
Replace per-process FD backing pointer with a numeric node_id and reserve node IDs 1–3 for stdin/stdout/stderr. Add FD helpers (is_empty/is_special), Process methods (get_free_fd_index, open_fd, close_fd), and initialize stdio FDs for kernel and newly created processes. Update process teardown to avoid closing the special stdio nodes and to safely decrement ref counts.

Extend VFS: introduce STDIN/STDOUT/STDERR constants, start real node IDs at 4, and split vfs_read into vfs_read(node_id, max_count) with a convenience vfs_read_node that reads to EOF.

Syscall changes: add Read and Write syscalls, improve open/close semantics with errors (EBADF, EINVAL), register opened node IDs into the process FD table, route writes to stdout/stderr to the framebuffer, and implement reading/writing through the VFS interfaces. Include bounds/error checks and safer ref-count handling.