### PR TITLE
feat: replace tty ring buffer with framebuffer-backed tty and add TtyWrite syscall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 *.iso
 *.hdd
 *.img
+/.claude
+/.omc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,6 +376,7 @@ dependencies = [
  "limine",
  "memory",
  "process",
+ "tty",
  "vfs",
 ]
 
@@ -384,8 +385,6 @@ name = "tty"
 version = "0.1.0"
 dependencies = [
  "framebuffer",
- "memory",
- "vfs",
 ]
 
 [[package]]

--- a/kernel/src/idt.rs
+++ b/kernel/src/idt.rs
@@ -91,7 +91,6 @@ pub fn idt_init() {
 
     idt[IDE_PRIMARY_VECTOR].set_handler_fn(ide_primary_handler);
     idt[IDE_SECONDARY_VECTOR].set_handler_fn(ide_secondary_handler);
-    idt[0x40].set_handler_fn(tty_handler);
 
     idt.load();
 
@@ -161,11 +160,6 @@ extern "x86-interrupt" fn ide_secondary_handler(_stack_frame: InterruptStackFram
     apic::apic_eoi();
 }
 
-extern "x86-interrupt" fn tty_handler(_stack_frame: InterruptStackFrame) {
-    let b = tty::tty_read_byte();
-    println!("Read byte: {}", b);
-    apic::apic_eoi();
-}
 
 fn init_syscall() {
     unsafe {

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -148,12 +148,8 @@ extern "C" fn kmain() -> ! {
         vfs_mount("ram", Box::new(ramfs::RamFs::new())).expect("Failed to mount empty ramfs");
     }
 
-    vfs_write("ram/tty", b"\0", O_RDWR | O_CREAT | O_TRUNC, 0o644)
-        .expect("Failed to write ram/tty");
-
     tty::tty_init();
-    let message = b"Hello from eucalyptOS!\n";
-    tty::tty_write(message);
+    tty::tty_write_str("eucalyptOS\n\n");
 
     loop {
         unsafe { core::arch::asm!("hlt"); }

--- a/syscall/Cargo.toml
+++ b/syscall/Cargo.toml
@@ -9,3 +9,4 @@ memory = { workspace = true }
 framebuffer = { workspace = true }
 vfs = { workspace = true }
 process = { workspace = true }
+tty = { workspace = true }

--- a/syscall/src/syscall_handler.rs
+++ b/syscall/src/syscall_handler.rs
@@ -9,12 +9,14 @@ unsafe extern "C" {
 }
 
 const ENOSYS: i64 = -38;
+const EINVAL: i64 = -22;
 
 #[repr(u64)]
 pub enum Syscall {
     PlotPoint       = 0,
     FramebufferInfo = 1,
     Print           = 2,
+    TtyWrite        = 3,
     Sbrk            = 5,
 }
 
@@ -24,6 +26,7 @@ impl Syscall {
             0 => Some(Self::PlotPoint),
             1 => Some(Self::FramebufferInfo),
             2 => Some(Self::Print),
+            3 => Some(Self::TtyWrite),
             5 => Some(Self::Sbrk),
             _ => None,
         }
@@ -42,6 +45,7 @@ impl SyscallHandler {
             Some(Syscall::PlotPoint)       => self.plot_point(arg1, arg2, arg3),
             Some(Syscall::FramebufferInfo) => self.framebuffer_info(arg1),
             Some(Syscall::Print)           => self.print(arg1, arg2),
+            Some(Syscall::TtyWrite)        => self.tty_write(arg1, arg2),
             Some(Syscall::Sbrk)            => self.sbrk(arg1),
             None => ENOSYS,
         }
@@ -58,7 +62,7 @@ impl SyscallHandler {
                 || x >= fb.width as i64
                 || y >= fb.height as i64
             {
-                return -1;
+                return EINVAL;
             }
 
             let pitch  = fb.pitch as i64;
@@ -98,6 +102,18 @@ impl SyscallHandler {
             }
         }
         0
+    }
+
+    // syscall 3: write bytes to the TTY
+    // arg1 = pointer to buffer, arg2 = length
+    // returns bytes written, or -EINVAL on bad args
+    fn tty_write(&self, ptr: i64, len: i64) -> i64 {
+        if ptr == 0 || len <= 0 || len > 65536 {
+            return EINVAL;
+        }
+        let slice = unsafe { core::slice::from_raw_parts(ptr as *const u8, len as usize) };
+        tty::tty_write(slice);
+        len
     }
 
     fn sbrk(&self, increment: i64) -> i64 {

--- a/tty/Cargo.toml
+++ b/tty/Cargo.toml
@@ -4,6 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-vfs = { workspace = true }
 framebuffer = { workspace = true }
-memory = { workspace = true }

--- a/tty/src/lib.rs
+++ b/tty/src/lib.rs
@@ -1,66 +1,25 @@
 #![no_std]
 
-extern crate alloc;
+use core::sync::atomic::{AtomicBool, Ordering};
+use framebuffer::{color, fill_screen, write_global};
 
-use core::ptr;
-use framebuffer::println;
-use memory;
+static INITIALIZED: AtomicBool = AtomicBool::new(false);
 
-static mut TTY_VIRT_ADDR: u64 = 0;
-
-#[repr(C)]
-struct TtyBuffer {
-    write_ptr: u32,
-    read_ptr: u32,
-    data: [u8; 4088],
-}
-
+/// Initialize the TTY: clears the screen and marks the tty as ready.
 pub fn tty_init() {
-    let phys = memory::frame_allocator::FrameAllocator::alloc_frame().expect("Failed to allocate frame");
-    let pml4 = memory::vmm::VMM::get_kernel_mapper().create_user_pml4().expect("PML4 creation failed");
-    let virt = memory::mmio::map_mmio(pml4, phys.as_u64(), 0x1000).expect("Mapping failed");
-    
-    unsafe {
-        TTY_VIRT_ADDR = virt;
-        let tty = &mut *(TTY_VIRT_ADDR as *mut TtyBuffer);
-        ptr::write_volatile(&mut tty.write_ptr, 0);
-        ptr::write_volatile(&mut tty.read_ptr, 0);
-    }
+    fill_screen(color::BLACK);
+    INITIALIZED.store(true, Ordering::Release);
 }
 
+/// Write raw bytes to the TTY. Silently drops output if called before tty_init.
 pub fn tty_write(data: &[u8]) {
-    for &byte in data {
-        tty_write_byte(byte);
+    if !INITIALIZED.load(Ordering::Acquire) {
+        return;
     }
+    write_global(data);
 }
 
-pub fn tty_read(buf: &mut [u8]) {
-    for i in 0..buf.len() {
-        buf[i] = tty_read_byte();
-    }
-}
-
-pub fn tty_write_byte(byte: u8) {
-    unsafe {
-        if TTY_VIRT_ADDR == 0 { return; }
-        let tty = &mut *(TTY_VIRT_ADDR as *mut TtyBuffer);
-        let index = (ptr::read_volatile(&tty.write_ptr) as usize) % tty.data.len();
-        ptr::write_volatile(&mut tty.data[index], byte);
-        ptr::write_volatile(&mut tty.write_ptr, tty.write_ptr.wrapping_add(1));
-        core::arch::asm!("int 0x40");
-    }
-}
-
-pub fn tty_read_byte() -> u8 {
-    unsafe {
-        if TTY_VIRT_ADDR == 0 { return 0; }
-        let tty = &mut *(TTY_VIRT_ADDR as *mut TtyBuffer);
-        while ptr::read_volatile(&tty.write_ptr) == ptr::read_volatile(&tty.read_ptr) {
-            core::hint::spin_loop();
-        }
-        let index = (ptr::read_volatile(&tty.read_ptr) as usize) % tty.data.len();
-        let byte = ptr::read_volatile(&tty.data[index]);
-        ptr::write_volatile(&mut tty.read_ptr, tty.read_ptr.wrapping_add(1));
-        byte
-    }
+/// Convenience wrapper for writing a UTF-8 string.
+pub fn tty_write_str(s: &str) {
+    tty_write(s.as_bytes());
 }


### PR DESCRIPTION
## what changed

  the old tty used a mapped physical frame as a shared ring buffer and
  fired int 0x40 on every byte written. the kernel-side handler would
  then read from it and println. this was slow, confusing, and didn't
  actually give you a real tty.

  the new tty is a thin wrapper over the framebuffer renderer:
  - tty_init() clears the screen and arms an initialized flag
  - tty_write() gates on that flag and calls framebuffer::write_global
  - no interrupts involved in the write path at all

  syscall 3 (TtyWrite) was added so userspace can write to the tty:
  - rdi = buffer pointer, rsi = length
  - returns bytes written or -EINVAL on bad args

  ## cleanup
  - removed int 0x40 idt entry and tty_handler
  - removed the vfs_write("ram/tty") stub from kmain
  - dropped unused vfs and memory deps from the tty crate
  - added .claude and .omc to .gitignore

  ## test plan
  - [ ] make run boots without panic
  - [ ] screen clears on tty_init
  - [ ] "eucalyptOS" appears on fresh screen after boot
  - [ ] userspace syscall 3 with valid ptr/len writes to screen
  - [ ] syscall 3 with null ptr returns -22
<img width="1009" height="1330" alt="Screenshot_20260417_144813" src="https://github.com/user-attachments/assets/63f3b19e-2afd-4420-a53d-2046c9c0c568" />
