### PR TITLE
feat: blocking tty read and ELF usermode entry

### DIFF
--- a/kernel/src/elf.rs
+++ b/kernel/src/elf.rs
@@ -2,7 +2,7 @@ use framebuffer::println;
 use elf_parser::elf64::Elf64;
 use vfs::{vfs_read, vfs_stat};
 use memory::vmm::VMM;
-use memory::paging::PageTableEntry;
+use memory::paging::{PageTable, PageTableEntry};
 use memory::addr::VirtAddr;
 use memory::frame_allocator::FrameAllocator;
 
@@ -105,4 +105,54 @@ pub fn load_elf(filename: &str) -> Option<(u64, u64)> {
     let entry = ehdr.e_entry;
     let pml4_phys = pml4 as u64;
     Some((entry, pml4_phys))
+}
+
+/// Allocates 4 pages for a user stack, maps them into `pml4`, and returns
+/// the virtual address of the stack top (highest address, 16-byte aligned).
+pub fn alloc_user_stack(pml4: *mut PageTable) -> Option<u64> {
+    const STACK_BASE: u64 = 0x0000_7FFF_FFF0_0000;
+    const STACK_PAGES: usize = 4;
+    let flags = PageTableEntry::PRESENT
+        | PageTableEntry::WRITABLE
+        | PageTableEntry::USER
+        | PageTableEntry::NO_EXECUTE;
+    let mapper = VMM::get_kernel_mapper();
+    for i in 0..STACK_PAGES {
+        let frame = FrameAllocator::alloc_frame()?;
+        let virt = VirtAddr::new(STACK_BASE + (i * PAGE_SIZE) as u64);
+        mapper.map_page(pml4, virt, frame, flags)?;
+    }
+    Some(STACK_BASE + (STACK_PAGES * PAGE_SIZE) as u64)
+}
+
+/// Switches the CPU to ring-3 and jumps to `entry` with `user_rsp` as the
+/// stack pointer. Never returns.
+///
+/// # Safety
+/// `entry` must be a valid user-mode virtual address mapped in the current
+/// address space. Caller must have loaded the correct CR3 beforehand.
+pub unsafe fn jump_to_usermode(entry: u64, user_rsp: u64) -> ! {
+    const USER_CS: u64 = 0x1B; // GDT index 3 | RPL 3
+    const USER_SS: u64 = 0x23; // GDT index 4 | RPL 3
+    const RFLAGS_IF: u64 = 0x202;
+    unsafe {
+        core::arch::asm!(
+            "mov ds, {ss:x}",
+            "mov es, {ss:x}",
+            "mov fs, {ss:x}",
+            "mov gs, {ss:x}",
+            "push {ss}",      // SS
+            "push {rsp}",     // RSP
+            "push {rfl}",     // RFLAGS
+            "push {cs}",      // CS
+            "push {rip}",     // RIP
+            "iretq",
+            ss  = in(reg) USER_SS,
+            rsp = in(reg) user_rsp,
+            rfl = in(reg) RFLAGS_IF,
+            cs  = in(reg) USER_CS,
+            rip = in(reg) entry,
+            options(noreturn),
+        );
+    }
 }

--- a/tty/src/lib.rs
+++ b/tty/src/lib.rs
@@ -6,10 +6,16 @@ use framebuffer::{color, fill_screen, write_global};
 
 static INITIALIZED: AtomicBool = AtomicBool::new(false);
 
+// --- editing buffer (filled by IRQ, mutated by backspace) ---
 struct LineBuf(UnsafeCell<[u8; 256]>);
 unsafe impl Sync for LineBuf {}
 static LINE_BUF: LineBuf = LineBuf(UnsafeCell::new([0u8; 256]));
 static LINE_LEN: AtomicUsize = AtomicUsize::new(0);
+
+// --- cooked buffer (one complete line waiting to be read) ---
+static COOKED_BUF: LineBuf = LineBuf(UnsafeCell::new([0u8; 256]));
+static COOKED_LEN: AtomicUsize = AtomicUsize::new(0);
+static LINE_READY: AtomicBool = AtomicBool::new(false);
 
 pub fn tty_init() {
     fill_screen(color::BLACK);
@@ -28,13 +34,23 @@ pub fn tty_write_str(s: &str) {
 }
 
 /// Called from the keyboard IRQ. Handles line editing and echoes to screen.
+/// On Enter, moves the editing buffer into the cooked buffer and sets LINE_READY.
 pub fn tty_handle_char(ch: u8) {
     if !INITIALIZED.load(Ordering::Acquire) {
         return;
     }
     match ch {
         b'\r' | b'\n' => {
+            let len = LINE_LEN.load(Ordering::Acquire);
+            // copy editing buf → cooked buf
+            unsafe {
+                let src = &*LINE_BUF.0.get();
+                let dst = &mut *COOKED_BUF.0.get();
+                dst[..len].copy_from_slice(&src[..len]);
+            }
+            COOKED_LEN.store(len, Ordering::Release);
             LINE_LEN.store(0, Ordering::Release);
+            LINE_READY.store(true, Ordering::Release);
             write_global(b"\n> ");
         }
         0x08 | 0x7F => {
@@ -54,4 +70,25 @@ pub fn tty_handle_char(ch: u8) {
         }
         _ => {}
     }
+}
+
+/// Blocks (spinning with `hlt`) until the user presses Enter, then copies the
+/// completed line into `buf` (without the newline) and returns the byte count.
+/// Returns 0 if `buf` is empty or the TTY is not yet initialized.
+pub fn tty_read_line(buf: &mut [u8]) -> usize {
+    if buf.is_empty() || !INITIALIZED.load(Ordering::Acquire) {
+        return 0;
+    }
+
+    // spin until Enter was pressed
+    while !LINE_READY.load(Ordering::Acquire) {
+        unsafe { core::arch::asm!("hlt") };
+    }
+
+    let len = COOKED_LEN.load(Ordering::Acquire).min(buf.len());
+    unsafe {
+        buf[..len].copy_from_slice(&(&(*COOKED_BUF.0.get()))[..len]);
+    }
+    LINE_READY.store(false, Ordering::Release);
+    len
 }


### PR DESCRIPTION
- tty: add cooked line buffer and tty_read_line() that hlt-spins until the user presses Enter, then returns the line without the newline
- elf: add alloc_user_stack() that maps 4 pages at 0x7FFF_FFF0_0000 and jump_to_usermode() iretq trampoline to switch CPU to ring 3